### PR TITLE
Fix flicker bug with marker popups

### DIFF
--- a/parks_style.css
+++ b/parks_style.css
@@ -19,3 +19,7 @@ body {
   background-color: #02599d;
   color: #ffffff;
 }
+
+.leaflet-popup-tip-container {
+  height: 10px;
+}

--- a/spc.js
+++ b/spc.js
@@ -17,7 +17,10 @@ L.tileLayer('https://{s}.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={
   }).addTo(map);
 
 function onEachFeature(feature, layer) {
-  layer.bindPopup(feature.properties.name);
+  layer.bindPopup(feature.properties.name, {
+    closeButton: false,
+    offset: L.point(0, -10)
+  });
   layer.on('mouseover', function (e) {
             this.openPopup();
             });


### PR DESCRIPTION
The popup flickering  / difficulty clicking on markers was caused by the `mouseout` event being triggered by the popup pointers/tips (and 10px of whitespace below the bottom of the tip). This PR removes the whitespace and pushes the popup up a bit.
